### PR TITLE
Resolves #22: Add ability for arbitrary reprojection

### DIFF
--- a/preprocess_toolbox/cli.py
+++ b/preprocess_toolbox/cli.py
@@ -158,3 +158,36 @@ def process_split_args(args: object,
 
         splits[split] = sorted(list(split_dates))
     return splits
+
+
+def parse_shape(value: str) -> tuple[int, int]:
+    """
+    Parse a shape argument into a tuple of integers.
+
+    This function takes a string representing shape dimensions.
+    If the input is a single value, it is duplicated to form a tuple of
+    length two. If multiple values are provided, they are converted into
+    a tuple.
+
+    Args:
+        value: A string containing one or more integers separated by commas,
+            representing shape dimensions.
+
+    Returns:
+        A tuple of two integers derived from the input string.
+
+    Examples:
+        parse_shape("5") returns (5, 5)
+        parse_shape("5,6") returns (5, 6)
+    """
+    if isinstance(value, int):
+        return (value, value)
+    else:
+        values = value.split(",")
+
+        # If only one value is provided, repeat it to create a tuple of length 2
+        if len(values) == 1:
+            values.append(values[0])
+        values = map(int, values)
+
+    return tuple(values)

--- a/preprocess_toolbox/dataset/cli.py
+++ b/preprocess_toolbox/dataset/cli.py
@@ -4,7 +4,7 @@ from dateutil.relativedelta import relativedelta
 
 from download_toolbox.interface import get_dataset_config_implementation, get_implementation
 
-from preprocess_toolbox.dataset.process import regrid_dataset, rotate_dataset
+from preprocess_toolbox.dataset.process import regrid_dataset, rotate_dataset, reproject_datasets_from_config
 from preprocess_toolbox.dataset.spatial import spatial_interpolation
 from preprocess_toolbox.dataset.time import process_missing_dates
 from preprocess_toolbox.cli import ProcessingArgParser, process_split_args, csv_arg
@@ -172,3 +172,84 @@ def rotate():
         rotate_dataset(args.reference, ds_config)
     ds_config.save_config()
 
+
+def reproject():
+    """
+    Reproject a dataset from one CRS to another CRS.
+
+    Example usage:
+        preprocess_reproject -v -c ./reproject.era5.day.north.json --workers 8 -ps train \
+        -sn train,val,test -ss 2023-1-1,2024-2-1,2024-12-1 -se 2023-12-31,2024-2-14,2024-12-1 \
+        -sh 4 -st 1 --source-crs 'EPSG:4326' --target-crs 'EPSG:6931' --shape 500 \
+        --ease2 data.aws.day.north.json proc.aws
+
+        This command reprojects an ERA5 lat/lon grid (EPSG:4326) to an EASE Grid 2.0 grid
+        (EPSG:6931) with an output shape of (500, 500). The dataset only processes dates
+        for the splits defined: 2023-1-1 to 2024-2-1, 2024-2-1 to 2024-12-1 and
+        2024-12-1 to 2025-1-1.
+        It adds 4 days prior to start and 1 day after due to `-sh` and `-st` flags.
+    """
+    args = (
+        ProcessingArgParser()
+        .add_destination()
+        .add_splits()
+        .add_extra_args(
+            [
+                (("-w", "--workers"), dict(default=1, type=int)),
+                (("-sc", "--source-crs"), dict(
+                        default="EPSG:4326",
+                        type=str,
+                        required=True,
+                        help="Source dataset CRS definition: EPSG code (e.g., `EPSG:4326`)",
+                )),
+                (("-tc", "--target-crs"), dict(
+                        default="EPSG:6931",
+                        type=str,
+                        required=False,
+                        help="Target dataset CRS definition: Full cartopy.crs expression (e.g., `EPSG:6931`)",
+                )),
+                (("-r", "--resolution"), dict(
+                        default=None,
+                        type=float,
+                        required=False,
+                        help="Resolution of output grid (in meters or degrees). Can only specify either `--resolution` or `--shape`, not both",
+                )),
+                (("-s", "--shape"), dict(
+                        default="720,720",
+                        type=str,
+                        required=False,
+                        help="Shape of output grid (in pixels, e.g. '720,720'). Can only specify either `--resolution` or `--shape`, not both",
+                )),
+                (("-e", "--ease2"), dict(
+                        action="store_true",
+                        help="Enable to output an EASE-Grid 2.0 conformal grid",
+                )),
+                (("-cn", "--coarsen"), dict(
+                        default=1,
+                        type=int,
+                        help="To coarsen output grid by this integer factor.",
+                )),
+                (("-in", "--interpolate-nans"), dict(
+                        action="store_true",
+                        help="Enable nearest neighbour interpolation to fill in missing areas.",
+                )),
+            ]
+        )
+        .parse_args()
+    )
+    # Initially copy across the source data from `./data/` to the destination
+    # `./processed_data/`
+    ds, ds_config = init_dataset(args)
+    # Reproject and overwrite the copied data
+    reproject_datasets_from_config(
+        ds_config,
+        source_crs=args.source_crs,
+        target_crs=args.target_crs,
+        resolution=args.resolution,
+        shape=args.shape,
+        ease2=args.ease2,
+        coarsen=args.coarsen,
+        interpolate_nans=args.interpolate_nans,
+        workers=args.workers,
+    )
+    ds_config.save_config()

--- a/preprocess_toolbox/dataset/process.py
+++ b/preprocess_toolbox/dataset/process.py
@@ -375,6 +375,6 @@ def reproject_datasets_from_config(
     else:
         logging.info("Reprojecting using one worker")
         for datafile in datafiles:
-            reproject_file(datafile)
+            reproject_file(datafile, ease2, **kwargs)
 
     logging.info("Reprojection completed")

--- a/preprocess_toolbox/dataset/process.py
+++ b/preprocess_toolbox/dataset/process.py
@@ -1,13 +1,21 @@
 import logging
 import os
 import re
+from pathlib import Path
 
 import iris
 import iris.analysis
 import iris.exceptions
 import numpy as np
+import rioxarray
+import xarray as xr
 
+from affine import Affine
 from download_toolbox.interface import DatasetConfig
+from joblib import Parallel, delayed
+from rasterio.enums import Resampling
+from rasterio.transform import from_origin
+from preprocess_toolbox.cli import parse_shape
 from preprocess_toolbox.dataset.spatial import (gridcell_angles_from_dim_coords,
                                                 invert_gridcell_angles,
                                                 rotate_grid_vectors)
@@ -162,3 +170,199 @@ def rotate_dataset(ref_file: os.PathLike,
             logging.debug("Overwritten {}".format(name))
 
     # merge_files(new_datafile, moved_datafile, self._drop_vars)
+
+
+def reproject_dataset(
+    netcdf_file: str,
+    source_crs: str | None = None,
+    target_crs: str | None = None,
+    resolution: float | tuple[float, float] | None = None,
+    shape: str | int | tuple[int, int] | None = None,
+    target_transform: Affine | None = None,
+    coarsen: int = 1,
+    interpolate_nans: bool = False,
+):
+    """
+    Reprojects a source dataset from source_crs to target_crs using
+    rioxarray.
+    """
+    if isinstance(netcdf_file, xr.Dataset) or isinstance(netcdf_file, xr.DataArray):
+        ds = netcdf_file
+    else:
+        ds = xr.open_dataset(netcdf_file, decode_coords="all")
+
+    source_crs = source_crs if source_crs else "EPSG:4326"
+    target_crs = target_crs if target_crs else "EPSG:6931"
+
+    if not hasattr(ds, "spatial_ref"):
+        logging.debug(
+            f"No spatial reference found in dataset, setting grid to: {source_crs}"
+        )
+        # This will add a `.spatial_ref`` attribute to the dataset,
+        # accessible via `ds.spatial_ref`.
+        # Assume that dataset is a lat/lon grid if `source_crs` is not defined
+        ds.rio.write_crs(source_crs, inplace=True)
+
+    if not isinstance(shape, tuple):
+        shape: tuple[int, int] = parse_shape(shape)
+
+    ds_reprojected = ds.rio.reproject(
+        target_crs,
+        resolution=resolution,
+        shape=shape,
+        # TODO: Missing antimeridian slice issue with Polar reprojection when using
+        # other resampling methods (e.g., bilinear, cubic)
+        resampling=Resampling.nearest,
+        nodata=np.nan,
+        transform=target_transform,
+    )
+
+    if interpolate_nans:
+        # Interpolate missing regions (nans), for CANARI, its below equator, might be
+        # useful if training mask doesn't align exactly?
+        ds_reprojected = ds_reprojected.rio.interpolate_na("nearest")
+
+    if coarsen > 1:
+        ds_reprojected = ds_reprojected.coarsen(
+            x=coarsen, y=coarsen, boundary="trim"
+        ).mean()
+
+    # TODO: Storing grid mapping attributes in the dataset to be CF Compliant
+    # This is more trouble than its worth currently - need to map the different
+    # projections which expect different attributes.
+    # target_crs_dict = target_crs.to_dict()
+    # semi_major_axis=target_crs.ellipsoid.semi_major_metre
+    # semi_minor_axis=target_crs.ellipsoid.semi_minor_metre
+    # latitude_of_projection_origin=target_crs_dict.get('lat_0', 0)
+    # longitude_of_projection_origin=target_crs_dict.get('lon_0', 0)
+    # false_easting=target_crs_dict.get('x_0', 0)
+    # false_northing=target_crs_dict.get('y_0', 0)
+
+    # grid_mapping_attrs = {
+    #     "grid_mapping_name": "lambert_azimuthal_equal_area",
+    #     "longitude_of_projection_origin": longitude_of_projection_origin,
+    #     "latitude_of_projection_origin": latitude_of_projection_origin,
+    #     "false_easting": false_easting,
+    #     "false_northing": false_northing,
+    #     "semi_major_axis": semi_major_axis,
+    #     "semi_minor_axis": semi_minor_axis,
+    # }
+
+    # # Add a new variable for the grid_mapping to the dataset
+    # ds_reprojected["projection"] = xr.DataArray(np.zeros(()), attrs=grid_mapping_attrs)
+
+    # # Link the 'data' variable to the 'projection' variable (through grid_mapping attribute)
+    # ds_reprojected["tas"].attrs["grid_mapping"] = "projection"
+
+    return ds_reprojected
+
+
+def reproject_dataset_ease2(
+    *args,
+    **kwargs,
+):
+    """Reproject a dataset to EASE-Grid 2.0 standard"""
+
+    target_crs = kwargs["target_crs"]
+    if target_crs is None:
+        raise ValueError("target_crs must be specified")
+    shape = kwargs.get("shape", (720, 720))
+    kwargs["shape"] = shape
+
+    if kwargs.get("resolution", None):
+        raise ValueError(
+            f"Resolution cannot be specified for EASE-Grid 2.0: {kwargs['resolution']}"
+        )
+
+    if not isinstance(shape, tuple):
+        shape: tuple[int, int] = parse_shape(shape)
+
+    if target_crs == "EPSG:6931" or target_crs == "EPSG:6932":
+        # Define grid parameters for EASE-Grid 2.0 standard grid
+        # Reference: https://nsidc.org/data/user-resources/help-center/guide-ease-grids#anchor-25-km-resolution-ease-grids
+        # `cell_size` is the grid resolution in meters taken from the table in above link
+        if shape == (720, 720):
+            cell_size = 25000
+        elif shape == (500, 500):
+            cell_size = 36000
+        else:
+            raise ValueError(
+                f"shape doesn't match expected EASE-Grid 2.0 standard grid:\n\t(`{shape}`)"
+            )
+        # The x-axis coordinate of the outer edge of the upper-left pixel
+        x0 = -9000000.0
+        # The y-axis coordinate of the outer edge of the upper-left pixel
+        y0 = 9000000.0
+    else:
+        raise ValueError(
+            f"target_crs doesn't match expected EASE-Grid 2.0 standard grid:\n\t(`{target_crs}`)"
+        )
+
+    # Create an affine transform for the target grid.
+    # from_origin expects (upper-left x, upper-left y, x resolution, y resolution)
+    target_transform = from_origin(x0, y0, cell_size, cell_size)
+
+    # # Define the target affine transform for EASE-Grid 2.0 (Northern Hemisphere)
+    # # Here, the pixel size is 25,000 m, with the top-left corner at (-9000000, 9000000)
+    # target_transform = Affine(25000, 0, -9000000,
+    #                           0, -25000, 9000000)
+
+    ds_reprojected = reproject_dataset(
+        *args, target_transform=target_transform, **kwargs
+    )
+
+    return ds_reprojected
+
+
+def reproject_datasets_from_config(
+    process_config: DatasetConfig, ease2=False, workers: int=1, **kwargs
+):
+    logging.info("Reprojecting dataset")
+
+    datafiles = [
+        _ for var_files in process_config.var_files.values() for _ in var_files
+    ]
+
+    def reproject_file(datafile):
+        try:
+            (datafile_path, datafile_name) = os.path.split(datafile)
+            reproject_source_name = f"_reproject_{datafile_name}"
+            reproject_datafile = Path(datafile_path) / reproject_source_name
+            os.rename(datafile, reproject_datafile)
+
+            logging.debug(f"Reprojecting {reproject_datafile}")
+
+            if ease2:
+                ds_reprojected = reproject_dataset_ease2(
+                    netcdf_file=reproject_datafile, **kwargs
+                )
+            else:
+                ds_reprojected = reproject_dataset(netcdf_file=reproject_datafile, **kwargs)
+
+            logging.debug(f"Saving reprojected data to {datafile}... ")
+            ds_reprojected.to_netcdf(datafile)
+        except Exception as e:
+            print(f"Error reprojecting {datafile}: {e}")
+            raise
+        finally:
+            # Ensure temp file is deleted
+            if os.path.exists(reproject_datafile):
+                os.remove(reproject_datafile)
+
+    # Parallel(n_jobs=workers, backend="threading", verbose=13)(
+    #     delayed(reproject_file)(datafile) for datafile in datafiles
+    # )
+
+    logging.info(f"{len(datafiles)} files to reproject")
+    if workers > 1:
+        logging.info(f"Reprojecting using {workers} workers")
+        # _ = thread_map(reproject_file, datafiles, max_workers=workers)
+        Parallel(n_jobs=workers, backend="loky", timeout=9999, verbose=51)(
+            delayed(reproject_file)(datafile) for datafile in datafiles
+        )
+    else:
+        logging.info("Reprojecting using one worker")
+        for datafile in datafiles:
+            reproject_file(datafile)
+
+    logging.info("Reprojection completed")

--- a/preprocess_toolbox/dataset/process.py
+++ b/preprocess_toolbox/dataset/process.py
@@ -181,10 +181,22 @@ def reproject_dataset(
     target_transform: Affine | None = None,
     coarsen: int = 1,
     interpolate_nans: bool = False,
-):
+) -> xr.Dataset:
     """
-    Reprojects a source dataset from source_crs to target_crs using
-    rioxarray.
+    Reprojects a source dataset from a source CRS to a target CRS using rioxarray.
+
+    Args:
+        netcdf_file: Path to the NetCDF file or an xarray Dataset/DataArray.
+        source_crs (optional): Source coordinate reference system (CRS). Defaults to "EPSG:4326".
+        target_crs (optional): Target coordinate reference system (CRS). Defaults to "EPSG:6931".
+        resolution (optional): Resolution of the target grid. Defaults to None.
+        shape (optional): Shape of the target grid. Defaults to None.
+        target_transform (optional): Affine transform for the target grid. Defaults to None.
+        coarsen (optional): Factor by which to coarsen the dataset. Defaults to 1.
+        interpolate_nans (optional): Whether to interpolate missing values (NaNs). Defaults to False.
+
+    Returns:
+        xarray.Dataset: Reprojected dataset.
     """
     if isinstance(netcdf_file, xr.Dataset) or isinstance(netcdf_file, xr.DataArray):
         ds = netcdf_file
@@ -235,9 +247,22 @@ def reproject_dataset(
 def reproject_dataset_ease2(
     *args,
     **kwargs,
-):
-    """Reproject a dataset to EASE-Grid 2.0 standard"""
+) -> xr.Dataset:
+    """
+    Reprojects a dataset to the EASE-Grid 2.0 standard.
 
+    Args:
+        *args: Positional arguments to pass to `reproject_dataset`.
+        **kwargs: Keyword arguments to pass to `reproject_dataset`. Must include:
+            - target_crs (str): Target CRS, must be "EPSG:6931" or "EPSG:6932".
+            - shape (tuple[int, int], optional): Shape of the target grid. Defaults to (720, 720).
+
+    Raises:
+        ValueError: If `target_crs` or `shape` does not match the EASE-Grid 2.0 standard.
+
+    Returns:
+        Reprojected dataset.
+    """
     target_crs = kwargs["target_crs"]
     if target_crs is None:
         raise ValueError("target_crs must be specified")
@@ -284,7 +309,18 @@ def reproject_dataset_ease2(
     return ds_reprojected
 
 
-def reproject_file(datafile, ease2, **kwargs):
+def reproject_file(datafile: str, ease2: bool = False, **kwargs) -> None:
+    """
+    Reprojects a single NetCDF file.
+
+    Args:
+        datafile (str): Path to the NetCDF file to reproject.
+        ease2 (optional): Whether to use EASE-Grid 2.0 standard for reprojection. Defaults to False.
+        **kwargs: Additional arguments to pass to `reproject_dataset` or `reproject_dataset_ease2`.
+
+    Raises:
+        Exception: If an error occurs during reprojection.
+    """
     try:
         (datafile_path, datafile_name) = os.path.split(datafile)
         reproject_source_name = f"_reproject_{datafile_name}"
@@ -313,7 +349,16 @@ def reproject_file(datafile, ease2, **kwargs):
 
 def reproject_datasets_from_config(
     process_config: DatasetConfig, ease2=False, workers: int=1, **kwargs
-):
+) -> None:
+    """
+    Reprojects multiple datasets from input config file.
+
+    Args:
+        process_config: Configuration object containing dataset file paths.
+        ease2 (optional): Whether to use EASE-Grid 2.0 standard for reprojection. Defaults to False.
+        workers (optional): Number of parallel workers to use. Defaults to 1.
+        **kwargs: Additional arguments to pass to `reproject_file`.
+    """
     logging.info("Reprojecting dataset")
 
     datafiles = [

--- a/preprocess_toolbox/dataset/process.py
+++ b/preprocess_toolbox/dataset/process.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
 import iris
@@ -12,7 +13,6 @@ import xarray as xr
 
 from affine import Affine
 from download_toolbox.interface import DatasetConfig
-from joblib import Parallel, delayed
 from rasterio.enums import Resampling
 from rasterio.transform import from_origin
 from preprocess_toolbox.cli import parse_shape
@@ -284,6 +284,33 @@ def reproject_dataset_ease2(
     return ds_reprojected
 
 
+def reproject_file(datafile, ease2, **kwargs):
+    try:
+        (datafile_path, datafile_name) = os.path.split(datafile)
+        reproject_source_name = f"_reproject_{datafile_name}"
+        reproject_datafile = Path(datafile_path) / reproject_source_name
+        os.rename(datafile, reproject_datafile)
+
+        logging.debug(f"Reprojecting {reproject_datafile}")
+
+        if ease2:
+            ds_reprojected = reproject_dataset_ease2(
+                netcdf_file=reproject_datafile, **kwargs
+            )
+        else:
+            ds_reprojected = reproject_dataset(netcdf_file=reproject_datafile, **kwargs)
+
+        logging.debug(f"Saving reprojected data to {datafile}... ")
+        ds_reprojected.to_netcdf(datafile)
+    except Exception as e:
+        print(f"Error reprojecting {datafile}: {e}")
+        raise
+    finally:
+        # Ensure temp file is deleted
+        if os.path.exists(reproject_datafile):
+            os.remove(reproject_datafile)
+
+
 def reproject_datasets_from_config(
     process_config: DatasetConfig, ease2=False, workers: int=1, **kwargs
 ):
@@ -293,43 +320,13 @@ def reproject_datasets_from_config(
         _ for var_files in process_config.var_files.values() for _ in var_files
     ]
 
-    def reproject_file(datafile):
-        try:
-            (datafile_path, datafile_name) = os.path.split(datafile)
-            reproject_source_name = f"_reproject_{datafile_name}"
-            reproject_datafile = Path(datafile_path) / reproject_source_name
-            os.rename(datafile, reproject_datafile)
-
-            logging.debug(f"Reprojecting {reproject_datafile}")
-
-            if ease2:
-                ds_reprojected = reproject_dataset_ease2(
-                    netcdf_file=reproject_datafile, **kwargs
-                )
-            else:
-                ds_reprojected = reproject_dataset(netcdf_file=reproject_datafile, **kwargs)
-
-            logging.debug(f"Saving reprojected data to {datafile}... ")
-            ds_reprojected.to_netcdf(datafile)
-        except Exception as e:
-            print(f"Error reprojecting {datafile}: {e}")
-            raise
-        finally:
-            # Ensure temp file is deleted
-            if os.path.exists(reproject_datafile):
-                os.remove(reproject_datafile)
-
-    # Parallel(n_jobs=workers, backend="threading", verbose=13)(
-    #     delayed(reproject_file)(datafile) for datafile in datafiles
-    # )
-
     logging.info(f"{len(datafiles)} files to reproject")
     if workers > 1:
         logging.info(f"Reprojecting using {workers} workers")
-        # _ = thread_map(reproject_file, datafiles, max_workers=workers)
-        Parallel(n_jobs=workers, backend="loky", timeout=9999, verbose=51)(
-            delayed(reproject_file)(datafile) for datafile in datafiles
-        )
+        with ProcessPoolExecutor(max_workers=workers) as executor:
+            futures = [executor.submit(reproject_file, datafile, ease2, **kwargs) for datafile in datafiles]
+
+        _ = [future.result() for future in futures]
     else:
         logging.info("Reprojecting using one worker")
         for datafile in datafiles:

--- a/preprocess_toolbox/dataset/process.py
+++ b/preprocess_toolbox/dataset/process.py
@@ -228,31 +228,6 @@ def reproject_dataset(
         ).mean()
 
     # TODO: Storing grid mapping attributes in the dataset to be CF Compliant
-    # This is more trouble than its worth currently - need to map the different
-    # projections which expect different attributes.
-    # target_crs_dict = target_crs.to_dict()
-    # semi_major_axis=target_crs.ellipsoid.semi_major_metre
-    # semi_minor_axis=target_crs.ellipsoid.semi_minor_metre
-    # latitude_of_projection_origin=target_crs_dict.get('lat_0', 0)
-    # longitude_of_projection_origin=target_crs_dict.get('lon_0', 0)
-    # false_easting=target_crs_dict.get('x_0', 0)
-    # false_northing=target_crs_dict.get('y_0', 0)
-
-    # grid_mapping_attrs = {
-    #     "grid_mapping_name": "lambert_azimuthal_equal_area",
-    #     "longitude_of_projection_origin": longitude_of_projection_origin,
-    #     "latitude_of_projection_origin": latitude_of_projection_origin,
-    #     "false_easting": false_easting,
-    #     "false_northing": false_northing,
-    #     "semi_major_axis": semi_major_axis,
-    #     "semi_minor_axis": semi_minor_axis,
-    # }
-
-    # # Add a new variable for the grid_mapping to the dataset
-    # ds_reprojected["projection"] = xr.DataArray(np.zeros(()), attrs=grid_mapping_attrs)
-
-    # # Link the 'data' variable to the 'projection' variable (through grid_mapping attribute)
-    # ds_reprojected["tas"].attrs["grid_mapping"] = "projection"
 
     return ds_reprojected
 
@@ -301,11 +276,6 @@ def reproject_dataset_ease2(
     # Create an affine transform for the target grid.
     # from_origin expects (upper-left x, upper-left y, x resolution, y resolution)
     target_transform = from_origin(x0, y0, cell_size, cell_size)
-
-    # # Define the target affine transform for EASE-Grid 2.0 (Northern Hemisphere)
-    # # Here, the pixel size is 25,000 m, with the top-left corner at (-9000000, 9000000)
-    # target_transform = Affine(25000, 0, -9000000,
-    #                           0, -25000, 9000000)
 
     ds_reprojected = reproject_dataset(
         *args, target_transform=target_transform, **kwargs

--- a/preprocess_toolbox/processor.py
+++ b/preprocess_toolbox/processor.py
@@ -237,12 +237,15 @@ class NormalisingChannelProcessor(Processor):
                 additional_lag_dates, dropped_lag_dates = get_extension_dates(ds_config, dates, self._lag_time, reverse=True)
                 dates += additional_lag_dates
                 drop_dates[split] += dropped_lag_dates
-
+                logging.info("Lag added {} dates for {} category: {} - {}".
+                             format(len(dates), split, min(dates), max(dates)))
             if self._lead_time > 0:
                 logging.info("Including lead of {} {}s".format(self._lead_time, ds_config.frequency.attribute))
                 additional_lead_dates, dropped_lead_dates = get_extension_dates(ds_config, dates, self._lead_time)
                 dates += additional_lead_dates
                 drop_dates[split] += dropped_lead_dates
+                logging.info("Lead added {} dates for {} category: {} - {}".
+                             format(len(dates), split, min(dates), max(dates)))
 
             split_dates_required[split] = sorted([_ for _ in dates if _ not in drop_dates[split]])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,13 @@ maintainers = [
 license = { file = "LICENSE" }
 dependencies = [
     "download-toolbox",
+    "joblib",
     "orjson",
-	"pip>=23.3",
-	"scitools-iris",
-	"wheel>=0.38.1",
+    "pip>=23.3",
+    "rioxarray",
+    "scitools-iris",
+    "wheel>=0.38.1",
+    "xarray[io]",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -39,6 +42,7 @@ classifiers = [
 preprocess_missing_spatial = "preprocess_toolbox.dataset.cli:missing_spatial"
 preprocess_missing_time = "preprocess_toolbox.dataset.cli:missing_time"
 preprocess_regrid = "preprocess_toolbox.dataset.cli:regrid"
+preprocess_reproject = "preprocess_toolbox.dataset.cli:reproject"
 preprocess_rotate = "preprocess_toolbox.dataset.cli:rotate"
 
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ maintainers = [
 license = { file = "LICENSE" }
 dependencies = [
     "download-toolbox",
-    "joblib",
     "orjson",
     "pip>=23.3",
     "rioxarray",


### PR DESCRIPTION
Resolves #22 

Add code to enable reprojection from one EPSG CRS to another using rioxarray.

This implementation is based on requirements for CANARI-ML, hence, may need adaptation/changes, open to comments.

As an example, to reproject ERA5 data downloaded using `AWSDownloader` of [download-toolbox](https://github.com/environmental-forecasting/download-toolbox) to an EASE Grid 2.0 for the northern hemisphere):

```bash
preprocess_reproject -v -c ./reproject.era5.day.north.json --workers 8 -ps train \
-sn train,val,test -ss 2023-1-1,2024-2-1,2024-12-1 -se 2023-12-31,2024-2-14,2024-12-1 \
-sh 4 -st 1 --source-crs 'EPSG:4326' --target-crs 'EPSG:6931' --shape 500 \
--ease2 data.aws.day.north.json proc.aws
```

* `-c`: Path to output of configuration post reprojection
* `-ps`: Processing splits
* `-sn`: Split names
* `-ss`: Split starts
* `-se`: Split ends
* `-sh`: Split head (how many days/months/... prior specified date to include)
* `-st`: Split tail (how many days/months/... post specified date to include)
* `--source-crs`: What the input dataset CRS is
* `--target-crs`: What the target CRS is
* `--shape`: The height and width to enforce on the reprojected grid. This can be a integer, or `'500,500)'`
* `--ease2`: Conform output to EASE Grid 2 standard. This expects shape of only 500 (36km resolution) or 720 (25km resolution).
* `data.aws.day.north.json`: JSON config output from download-toolbox of source data
* `proc.aws`: Identifier to use for output, in this case, outputs will go to: `processed_data/proc.aws/...`