### PR TITLE
Resolve #37: Non default output dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,5 +108,8 @@ ENV/
 .vscode/
 .idea/
 
+# vim
+*.swp
+
 /data/
 /preprocess_toolbox/scratches/

--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ ENV/
 
 # vim
 *.swp
+*.swo
 
 /data/
 /preprocess_toolbox/scratches/

--- a/preprocess_toolbox/cli.py
+++ b/preprocess_toolbox/cli.py
@@ -16,13 +16,14 @@ from download_toolbox.interface import Frequency
 class ProcessingArgParser(BaseArgParser):
     def __init__(self,
                  *args,
+                 base_path="processed_data",
                  **kwargs):
         super().__init__(*args, **kwargs)
 
         self.add_argument("source", type=str)
         self.add_argument("-p", "--destination-path",
                           help="Folder that any output data collections will be put in",
-                          type=str, default="processed_data")
+                          type=str, default=base_path)
 
     def add_ref_ds(self):
         self.add_argument("reference", type=str)

--- a/preprocess_toolbox/dataset/cli.py
+++ b/preprocess_toolbox/dataset/cli.py
@@ -25,6 +25,11 @@ def process_dataset():
     ds_config = get_dataset_config_implementation(args.source)
     splits = process_split_args(args, frequency=ds_config.frequency)
 
+    # Overwrite argparse default for this func if base path not provided
+    base_path = args.destination_path
+    if base_path == "processed_data":
+        base_path = os.path.join(".", "processed")
+
     implementation = NormalisingChannelProcessor \
         if args.implementation is None \
         else get_implementation(args.implementation)
@@ -36,6 +41,7 @@ def process_dataset():
                           anom_clim_splits=args.processing_splits,
                           config_path=args.config,
                           identifier=args.destination_id,
+                          base_path=base_path,
                           # TODO: nomenclature is old here, lag and lead make sense in forecasting, but not in here
                           #  so this mapping should be revised throughout the library - we don't necessarily forecast!
                           lag_time=args.split_head,

--- a/preprocess_toolbox/dataset/cli.py
+++ b/preprocess_toolbox/dataset/cli.py
@@ -14,7 +14,7 @@ from preprocess_toolbox.utils import get_config
 
 
 def process_dataset():
-    args = (ProcessingArgParser().
+    args = (ProcessingArgParser(base_path="processed").
             add_concurrency().
             add_destination().
             add_implementation().
@@ -24,11 +24,6 @@ def process_dataset():
             add_vars()).parse_args()
     ds_config = get_dataset_config_implementation(args.source)
     splits = process_split_args(args, frequency=ds_config.frequency)
-
-    # Overwrite argparse default for this func if base path not provided
-    base_path = args.destination_path
-    if base_path == "processed_data":
-        base_path = os.path.join(".", "processed")
 
     implementation = NormalisingChannelProcessor \
         if args.implementation is None \
@@ -41,7 +36,7 @@ def process_dataset():
                           anom_clim_splits=args.processing_splits,
                           config_path=args.config,
                           identifier=args.destination_id,
-                          base_path=base_path,
+                          base_path=args.destination_path,
                           # TODO: nomenclature is old here, lag and lead make sense in forecasting, but not in here
                           #  so this mapping should be revised throughout the library - we don't necessarily forecast!
                           lag_time=args.split_head,

--- a/preprocess_toolbox/loader/cli.py
+++ b/preprocess_toolbox/loader/cli.py
@@ -51,6 +51,9 @@ class MetaArgParser(LoaderArgParser):
         self.add_argument("-p", "--destination-path",
                           help="Folder that any output data collections will be put in",
                           type=str, default=base_path)
+        self.add_argument("-l", "--loader-path",
+                          help="Path to the loader JSON config file to load",
+                          type=str, default=None)
 
     def add_channel(self):
         self.add_argument("channel_name")
@@ -74,6 +77,9 @@ def create():
         channels=dict(),
     )
     destination_path = get_config_filename(args)
+    destination_directory = os.path.dirname(destination_path)
+    if destination_directory:
+        os.makedirs(destination_directory, exist_ok=True)
 
     if not os.path.exists(destination_path):
         with open(destination_path, "w") as fh:
@@ -129,24 +135,31 @@ def add_processed():
 
 
 def get_channel_info_from_processor(cfg_segment: str):
-    args = (MetaArgParser(base_path="processed").
+    args, unknown_args = (MetaArgParser(base_path="processed").
             add_channel().
-            parse_args())
+            parse_known_args())
 
     proc_impl = get_implementation(args.implementation)
     ds_config = get_dataset_config_implementation(args.ground_truth_dataset)
 
     if args.config is not None:
-        # FIXME: args.config contains the location of the dataset config on render, but
-        #   this is not part of this pattern! DS is either ground truth or in derived class,
-        #   but this library doesn't care or know of it respectively.
-        raise RuntimeError("--config-path is invalid for this CLI endpoint, sorry...")
+       # FIXME: args.config contains the location of the dataset config on render, but
+       #   this is not part of this pattern! DS is either ground truth or in derived class,
+       #   but this library doesn't care or know of it respectively.
+       raise RuntimeError("--config-path is invalid for this CLI endpoint, sorry...")
 
-    processor = proc_impl(ds_config,
-                          [args.channel_name,],
-                          args.channel_name,
-                          base_path=args.destination_path,
-                         )
+    impl_args = (
+        ds_config,
+        [
+            args.channel_name,
+        ],
+        args.channel_name,
+    )
+    impl_kwargs = {"base_path": args.destination_path}
+    if unknown_args:
+        impl_kwargs |= unknown_args
+
+    processor = proc_impl(*impl_args, **impl_kwargs)
     processor.process()
     update_config(get_config_filename(args),
                   cfg_segment,

--- a/preprocess_toolbox/loader/cli.py
+++ b/preprocess_toolbox/loader/cli.py
@@ -45,12 +45,12 @@ class LoaderArgParser(BaseArgParser):
 
 
 class MetaArgParser(LoaderArgParser):
-    def __init__(self):
+    def __init__(self, base_path="processed_data"):
         super().__init__()
         self.add_argument("ground_truth_dataset")
         self.add_argument("-p", "--destination-path",
                           help="Folder that any output data collections will be put in",
-                          type=str, default="processed_data")
+                          type=str, default=base_path)
 
     def add_channel(self):
         self.add_argument("channel_name")
@@ -129,7 +129,7 @@ def add_processed():
 
 
 def get_channel_info_from_processor(cfg_segment: str):
-    args = (MetaArgParser().
+    args = (MetaArgParser(base_path="processed").
             add_channel().
             parse_args())
 
@@ -142,15 +142,10 @@ def get_channel_info_from_processor(cfg_segment: str):
         #   but this library doesn't care or know of it respectively.
         raise RuntimeError("--config-path is invalid for this CLI endpoint, sorry...")
 
-    # Overwrite argparse default for this func if base path not provided
-    base_path = args.destination_path
-    if base_path == "processed_data":
-        base_path = os.path.join(".", "processed")
-
     processor = proc_impl(ds_config,
                           [args.channel_name,],
                           args.channel_name,
-                          base_path=base_path,
+                          base_path=args.destination_path,
                          )
     processor.process()
     update_config(get_config_filename(args),

--- a/preprocess_toolbox/loader/cli.py
+++ b/preprocess_toolbox/loader/cli.py
@@ -142,9 +142,16 @@ def get_channel_info_from_processor(cfg_segment: str):
         #   but this library doesn't care or know of it respectively.
         raise RuntimeError("--config-path is invalid for this CLI endpoint, sorry...")
 
+    # Overwrite argparse default for this func if base path not provided
+    base_path = args.destination_path
+    if base_path == "processed_data":
+        base_path = os.path.join(".", "processed")
+
     processor = proc_impl(ds_config,
                           [args.channel_name,],
-                          args.channel_name)
+                          args.channel_name,
+                          base_path=base_path,
+                         )
     processor.process()
     update_config(get_config_filename(args),
                   cfg_segment,

--- a/preprocess_toolbox/processor.py
+++ b/preprocess_toolbox/processor.py
@@ -502,6 +502,7 @@ class NormalisingChannelProcessor(Processor):
 
         return {
             "implementation": "{}:{}".format(self.__module__, self.__class__.__name__),
+            "base_path": self._base_path,
             "anomoly_vars": self._anom_vars,
             "absolute_vars": self.abs_vars,
             "dataset_config": self._dataset_config,

--- a/preprocess_toolbox/utils.py
+++ b/preprocess_toolbox/utils.py
@@ -25,6 +25,13 @@ def get_config_filename(args: argparse.Namespace, prefix: str = "loader"):
     if prefix is not None:
         default_loader_config = "{}.{}".format(prefix, default_loader_config)
 
+    if (
+        "loader_path" in args
+        and args.loader_path is not None
+        and (os.path.isfile(args.loader_path) or not os.path.exists(args.loader_path))
+    ):
+        return args.loader_path
+
     # TODO: this is a bit grim, but to allow different config output paths it's very flexible. refactor
     if args.config is not None and (os.path.isfile(args.config) or not os.path.exists(args.config)):
         logging.warning("{} has been specified, overriding default name {}".format(args.config, args.name))


### PR DESCRIPTION
Respect CLI `--destination-path` output location, and add it to config definition as well.

Relies on https://github.com/environmental-forecasting/download-toolbox/pull/54