### PR TITLE
Use h5netcdf engine to read in processor.py

### DIFF
--- a/preprocess_toolbox/processor.py
+++ b/preprocess_toolbox/processor.py
@@ -396,6 +396,7 @@ class NormalisingChannelProcessor(Processor):
                     # data so this was harder. Now we work with whatever we get from download-toolbox
                     ds = xr.open_mfdataset(
                         source_files,
+                        engine="h5netcdf",
                         parallel=self._parallel,
                         lock=False)
                     da = getattr(ds, var_name)


### PR DESCRIPTION
Fixes Seg Fault issue when preprocessor attempts to read from a netcdf file with chunked dataarrays.

Refs: #40